### PR TITLE
画像投稿機能の修正

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -70,6 +70,7 @@ $(function() {
       $('.chat').attr('id', data.id)
       $('.messages').append(html)
       $('.message-form__text-field').val('');
+      $('#message_image').val('');
       $(".messages").animate({scrollTop: $('.messages')[0].scrollHeight});
       $('.send-button').prop("disabled", false);
     })


### PR DESCRIPTION
#What
一度画像投稿をすると、それ以降の投稿に全てその画像がついてしまうのを修正する

#Why
サービスに必須のため